### PR TITLE
Break homepage into two tables

### DIFF
--- a/_data/builds.yml
+++ b/_data/builds.yml
@@ -142,35 +142,3 @@ boards:
       jenkins_build_url: https://ci.linaro.org/view/lkft/job/openembedded-lkft-linux-next/DISTRO=rpb,MACHINE=intel-core2-32,label=docker-stretch-amd64/
       jenkins_badge_url: https://ci.linaro.org/buildStatus/icon?job=openembedded-lkft-linux-next/DISTRO=rpb,MACHINE=intel-core2-32,label=docker-stretch-amd64
       squad_url: https://qa-reports.linaro.org/lkft/linux-next-oe/
-
-- name: QEMU x86_64
-  architecture: x86_64
-  branches:
-    "4.4 RC":
-      squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-4.4-oe/
-    "4.9 RC":
-      squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-4.9-oe/
-    "4.14 RC":
-      squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-4.14-oe/
-    "4.15 RC":
-      squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-4.15-oe/
-    "mainline":
-      squad_url: https://qa-reports.linaro.org/lkft/linux-mainline-oe/
-    "linux-next":
-      squad_url: https://qa-reports.linaro.org/lkft/linux-next-oe/
-
-- name: QEMU arm64
-  architecture: arm64
-  branches:
-    "4.4 RC":
-      squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-4.4-oe/
-    "4.9 RC":
-      squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-4.9-oe/
-    "4.14 RC":
-      squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-4.14-oe/
-    "4.15 RC":
-      squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-4.15-oe/
-    "mainline":
-      squad_url: https://qa-reports.linaro.org/lkft/linux-mainline-oe/
-    "linux-next":
-      squad_url: https://qa-reports.linaro.org/lkft/linux-next-oe/

--- a/_data/tests.yml
+++ b/_data/tests.yml
@@ -1,0 +1,23 @@
+
+tests:
+  branches:
+    - name: "4.4"
+      squad_url: https://qa-reports.linaro.org/lkft/linux-stable-4.4-oe/
+    - name: "4.4 RC"
+      squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-4.4-oe/
+    - name: "4.9"
+      squad_url: https://qa-reports.linaro.org/lkft/linux-stable-4.9-oe/
+    - name: "4.9 RC"
+      squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-4.9-oe/
+    - name: "4.14"
+      squad_url: https://qa-reports.linaro.org/lkft/linux-stable-4.14-oe/
+    - name: "4.14 RC"
+      squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-4.14-oe/
+    - name: "4.15"
+      squad_url: https://qa-reports.linaro.org/lkft/linux-stable-4.15-oe/
+    - name: "4.15 RC"
+      squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-4.15-oe/
+    - name: "mainline"
+      squad_url: https://qa-reports.linaro.org/lkft/linux-mainline-oe/
+    - name: "linux-next"
+      squad_url: https://qa-reports.linaro.org/lkft/linux-next-oe/

--- a/index.md
+++ b/index.md
@@ -2,35 +2,53 @@
 layout: home
 ---
 
+## Test Results
+<table class="table-responsive table-boards">
+<thead><tr>
+{% for branch in site.data.tests.tests.branches %}
+    <th>{{branch.name}}</th>
+{% endfor %}
+</tr></thead>
+<tbody>
+<tr>
+{% for branch in site.data.tests.tests.branches %}
+    <td>
+    <a href="{{branch.squad_url}}">
+        <img src="squad_favicon.png" alt="Squad Logo" />
+    </a>
+    </td>
+{% endfor %}
+</tr>
+</tbody>
+</table>
+
+
+## Build Status
 <table class="table-responsive table-boards">
 <thead><tr>
 <th>Board</th>
-{% for branch in site.data.boards.branches %}
+{% for branch in site.data.builds.branches %}
     <th>{{branch}}</th>
 {% endfor %}
 </tr></thead>
 <tbody>
-{% for board in site.data.boards.boards %}
+{% for board in site.data.builds.boards %}
     <tr>
         <td>
             <strong>{{board.name}}</strong>
             <br />
             {{board.architecture}}
         </td>
-        {% for branch in site.data.boards.branches %}
+        {% for branch in site.data.builds.branches %}
             <td>
                 {% if board.branches contains branch %}
-                    {% if board.branches[branch] contains "jenkins_build_url" and 
+                    {% if board.branches[branch] contains "jenkins_build_url" and
                           board.branches[branch] contains "jenkins_badge_url" %}
                         <a href="{{board.branches[branch].jenkins_build_url}}">
                             <img src="{{board.branches[branch].jenkins_badge_url}}"
                             alt="Jenkins Build Badge" />
                         </a>
-                        <br />
                     {% endif %}
-                    <a href="{{board.branches[branch].squad_url}}">
-                        <img src="squad_favicon.png" alt="Squad Logo" />
-                    </a>
                 {% else %}
                     N/A
                 {% endif %}
@@ -40,3 +58,4 @@ layout: home
 {% endfor %}
 </tbody>
 </table>
+


### PR DESCRIPTION
One for test result links. The other for build status. On the previous
table, all the result links for a given branch went to the same place,
so it didn't make sense to list them alongside build status.

The build table does not show the non-RC branches for space reasons.

Test results should be more dynamic and not a table.. TBD.

Signed-off-by: Dan Rue <dan.rue@linaro.org>