### PR TITLE
Improve redirect logic

### DIFF
--- a/_data/routingrules.json
+++ b/_data/routingrules.json
@@ -1,0 +1,4 @@
+[
+  "^/changelog(/?|/index.html)$ /logs/changelog/ [R,L,NC]",
+  "^/logs(/?|/index.html)$ /logs/changelog/ [R,L,NC]"
+]

--- a/logs/changelog/index.md
+++ b/logs/changelog/index.md
@@ -2,9 +2,6 @@
 layout: container-breadcrumb
 title: Changelog
 permalink: /logs/changelog/
-redirect_from:
-  - /changelog # historical
-  - /logs # Let 'changelog' be default logs page
 ---
 
 # Linux Kernel Functional Testing (LKFT) Changelog

--- a/logs/index.md
+++ b/logs/index.md
@@ -1,5 +1,5 @@
 ---
 layout: container-breadcrumb
 title: Logs
-permalink: /logs
+permalink: /logs/
 ---

--- a/logs/rclog/index.md
+++ b/logs/rclog/index.md
@@ -2,7 +2,6 @@
 layout: container-breadcrumb
 title: Stable Release Candidate Log
 permalink: /logs/rclog/
-redirect_from: /rclog
 ---
 
 Log of status and events while doing stable tree release candidate testing in


### PR DESCRIPTION
- It's not needed for rclog; it was never published
- changelog and logs need a trailing / to be correct
- logs/index.md is not needed

Signed-off-by: Dan Rue <dan.rue@linaro.org>