### PR TITLE
Misc. Updates

### DIFF
--- a/_data/clang-builds.yml
+++ b/_data/clang-builds.yml
@@ -1,0 +1,37 @@
+toolchains:
+- AOSP
+- Clang
+architectures:
+- arm64
+- x86_64
+branches:
+- name: "4.17"
+  AOSP:
+    arm64:
+      jenkins_build_url: https://ci.linaro.org/job/trigger-lkft-linux-clang-stable/
+      jenkins_badge_url: https://ci.linaro.org/buildStatus/icon?job=trigger-lkft-linux-clang-stable
+    x86_64:
+      jenkins_build_url: https://ci.linaro.org/job/trigger-lkft-linux-clang-stable/
+      jenkins_badge_url: https://ci.linaro.org/buildStatus/icon?job=trigger-lkft-linux-clang-stable
+  Clang:
+    arm64:
+      jenkins_build_url: https://ci.linaro.org/job/trigger-lkft-linux-clang-stable/
+      jenkins_badge_url: https://ci.linaro.org/buildStatus/icon?job=trigger-lkft-linux-clang-stable
+    x86_64:
+      jenkins_build_url: https://ci.linaro.org/job/trigger-lkft-linux-clang-stable/
+      jenkins_badge_url: https://ci.linaro.org/buildStatus/icon?job=trigger-lkft-linux-clang-stable
+- name: "mainline"
+  AOSP:
+    arm64:
+      jenkins_build_url: https://ci.linaro.org/job/trigger-lkft-linux-clang-mainline/
+      jenkins_badge_url: https://ci.linaro.org/buildStatus/icon?job=trigger-lkft-linux-clang-mainline
+    x86_64:
+      jenkins_build_url: https://ci.linaro.org/job/trigger-lkft-linux-clang-mainline/
+      jenkins_badge_url: https://ci.linaro.org/buildStatus/icon?job=trigger-lkft-linux-clang-mainline
+  Clang:
+    arm64:
+      jenkins_build_url: https://ci.linaro.org/job/trigger-lkft-linux-clang-mainline/
+      jenkins_badge_url: https://ci.linaro.org/buildStatus/icon?job=trigger-lkft-linux-clang-mainline
+    x86_64:
+      jenkins_build_url: https://ci.linaro.org/job/trigger-lkft-linux-clang-mainline/
+      jenkins_badge_url: https://ci.linaro.org/buildStatus/icon?job=trigger-lkft-linux-clang-mainline

--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -1,3 +1,6 @@
+# Clang build table on homepage
+clang_enabled: false
+
 # Mailchimp settings
 mailchimp:
     enabled: false

--- a/index.md
+++ b/index.md
@@ -3,12 +3,16 @@ layout: home
 ---
 
 ## Test Results
-<div>
+<div class="container">
+<div class="row">
 {% for branch in site.data.tests.tests.branches %}
+<div class="col-6 col-md-4">
     <a href="{{branch.squad_url}}">
         <img src="{{branch.squad_url}}badge" alt="Squad Logo" />
     </a>
+</div>
 {% endfor %}
+</div>
 </div>
 
 ## Build Status

--- a/index.md
+++ b/index.md
@@ -51,3 +51,41 @@ layout: home
 </tbody>
 </table>
 
+{% if site.data.settings.clang_enabled %}
+## Clang Build Status
+In an effort to support building the Linux kernel using <a
+href="https://clang.llvm.org/">clang</a>, the following table provides the
+current status of a kernel build on several branches, clang distributions, and
+architectures.
+<table class="table-responsive table-boards">
+<thead>
+  <tr>
+    <th>Branch</th>
+    {% for toolchain in site.data.clang-builds.toolchains %}
+      {% for architecture in site.data.clang-builds.architectures %}
+        <th>{{toolchain}} - {{architecture}}</th>
+      {% endfor %}
+    {% endfor %}
+  </tr>
+</thead>
+<tbody>
+{% for branch in site.data.clang-builds.branches %}
+  <tr>
+    <td>
+      <strong>{{branch.name}}</strong>
+    </td>
+    {% for toolchain in site.data.clang-builds.toolchains %}
+      {% for architecture in site.data.clang-builds.architectures %}
+        <td>
+          <a href="{{branch[toolchain][architecture].jenkins_build_url}}">
+            <img src="{{branch[toolchain][architecture].jenkins_badge_url}}"
+            alt="Jenkins Build Badge" />
+          </a>
+        </td>
+      {% endfor %}
+    {% endfor %}
+  </tr>
+{% endfor %}
+</tbody>
+</table>
+{% endif %}

--- a/logs/changelog/index.md
+++ b/logs/changelog/index.md
@@ -10,7 +10,7 @@ This log is a high level overview of changes in the LKFT environment and
 infrastructure.
 
 ## 2018
-
+- 2018-07-19: OpenEmbedded build moved from Morty to Rocko
 - 2018-07-16: [qa-reports](https://qa-reports.linaro.org/) upgraded to [SQUAD
   0.47](https://github.com/Linaro/squad/blob/master/CHANGELOG.md)
 - 2018-07-06: [LTP Open


### PR DESCRIPTION
- Implementation for clang build results displayed on homepage. Disabled for now until jenkins work is finished. See https://storage.googleapis.com/openscreenshot/X/V/y/S1y7BcyVX.png for a screenshot of what it will look like.
- Update Changelog to note the OE upgrade to Rocko
- Align test badges on homepage