### PR TITLE
Preserving kernel branch order

### DIFF
--- a/_data/tests.yml
+++ b/_data/tests.yml
@@ -4,24 +4,32 @@ tests:
     - name: "4.4"
       project_url: "https://qa-reports.linaro.org/api/projects/40/"
       squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-4.4-oe/
+      order_num: 1
     - name: "4.9"
       project_url: "https://qa-reports.linaro.org/api/projects/23/"
       squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-4.9-oe/
+      order_num: 2
     - name: "4.14"
       project_url: "https://qa-reports.linaro.org/api/projects/58/"
       squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-4.14-oe/
+      order_num: 3
     - name: "4.19"
       project_url: "https://qa-reports.linaro.org/api/projects/135/"
       squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-4.19-oe/
+      order_num: 4
     - name: "5.3"
       project_url: "https://qa-reports.linaro.org/api/projects/204/"
       squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-5.3-oe/
+      order_num: 5
     - name: "5.4"
       project_url: "https://qa-reports.linaro.org/api/projects/232/"
       squad_url: https://qa-reports.linaro.org/lkft/linux-stable-rc-5.4-oe/
+      order_num: 6
     - name: "mainline"
       project_url: "https://qa-reports.linaro.org/api/projects/22/"
       squad_url: https://qa-reports.linaro.org/lkft/linux-mainline-oe/
+      order_num: 7
     - name: "linux-next"
       project_url: "https://qa-reports.linaro.org/api/projects/6/"
       squad_url: https://qa-reports.linaro.org/lkft/linux-next-oe/
+      order_num: 8

--- a/assets/js/app/test_results.js
+++ b/assets/js/app/test_results.js
@@ -37,6 +37,7 @@ $.when($.getJSON("/assets/json/tests.json")).done(function(json) {
       // Setup the project_details object
       var project_details = {
         url: original_project["squad_url"],
+        order_num: original_project["order_num"],
         builds: "",
         project: project,
         name: project["slug"],
@@ -73,7 +74,6 @@ $.when($.getJSON("/assets/json/tests.json")).done(function(json) {
   function getTimeDelta(datetimeObj) {
     return Math.abs(Math.round((new Date() - datetimeObj) / 1000 / 60 / 60));
   }
-
   // Create a HTML list element for a given set of test data.
   function createProjectList(build_data) {
     var elements = [];
@@ -201,10 +201,10 @@ $.when($.getJSON("/assets/json/tests.json")).done(function(json) {
   }
   function presentData(build_data) {
     var sorted_build_data = build_data.sort(function(a, b) {
-      if (a.name < b.name) {
+      if (a.order_num < b.order_num) {
         return -1;
       }
-      if (a.name > b.name) {
+      if (a.order_num > b.order_num) {
         return 1;
       }
       return 0;


### PR DESCRIPTION
This PR preserves the order of kernel branches based on the entries in _data/tests.yml
Fixes: https://github.com/Linaro/lkft-website/issues/222 